### PR TITLE
Set Vite base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/Project-Alive-2/',
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],


### PR DESCRIPTION
## Summary
- configure the Vite base path so the app serves correctly from /Project-Alive-2/ when deployed on GitHub Pages

## Testing
- npm run build
- npm run preview

------
https://chatgpt.com/codex/tasks/task_e_68d2a3262e6c8331891534351e2bf0a1