### PR TITLE
Set Vite base to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/Project-Alive-2/',
+  base: '/',
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],


### PR DESCRIPTION
## Summary
- update the Vite configuration to serve assets from the root path
- add a gitignore so dist and node_modules are not tracked

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2a67ed44883318ea6365246bed5b0