### PR TITLE
Safely access localStorage to avoid blank page

### DIFF
--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import { safeGetItem, safeRemoveItem, safeSetItem } from '../utils/storage';
 
 interface FinancialData {
   revenue: { current: number; previous: number };
@@ -162,10 +163,10 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
 
   const saveData = () => {
     try {
-      localStorage.setItem('pegase_financial_data', JSON.stringify(financialData));
-      localStorage.setItem('pegase_qoe_adjustments', JSON.stringify(qoeAdjustments));
-      localStorage.setItem('pegase_imported_files', JSON.stringify(importedFiles));
-      localStorage.setItem('pegase_last_save', new Date().toISOString());
+      safeSetItem('pegase_financial_data', JSON.stringify(financialData));
+      safeSetItem('pegase_qoe_adjustments', JSON.stringify(qoeAdjustments));
+      safeSetItem('pegase_imported_files', JSON.stringify(importedFiles));
+      safeSetItem('pegase_last_save', new Date().toISOString());
     } catch (error) {
       console.error('Error saving data:', error);
     }
@@ -173,9 +174,9 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
 
   const loadData = () => {
     try {
-      const savedFinancialData = localStorage.getItem('pegase_financial_data');
-      const savedQoeAdjustments = localStorage.getItem('pegase_qoe_adjustments');
-      const savedImportedFiles = localStorage.getItem('pegase_imported_files');
+      const savedFinancialData = safeGetItem('pegase_financial_data');
+      const savedQoeAdjustments = safeGetItem('pegase_qoe_adjustments');
+      const savedImportedFiles = safeGetItem('pegase_imported_files');
 
       if (savedFinancialData) {
         setFinancialData(JSON.parse(savedFinancialData));
@@ -192,10 +193,10 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
   };
 
   const clearData = () => {
-    localStorage.removeItem('pegase_financial_data');
-    localStorage.removeItem('pegase_qoe_adjustments');
-    localStorage.removeItem('pegase_imported_files');
-    localStorage.removeItem('pegase_last_save');
+    safeRemoveItem('pegase_financial_data');
+    safeRemoveItem('pegase_qoe_adjustments');
+    safeRemoveItem('pegase_imported_files');
+    safeRemoveItem('pegase_last_save');
     
     // Reset to default values
     setFinancialData({

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import { safeGetItem, safeSetItem } from '../utils/storage';
 
 interface ThemeContextType {
   isDark: boolean;
@@ -9,17 +10,20 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [isDark, setIsDark] = useState(() => {
-    const saved = localStorage.getItem('theme');
+    const saved = safeGetItem('theme');
     return saved ? saved === 'dark' : false;
   });
 
   useEffect(() => {
-    if (isDark) {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
+    if (typeof document !== 'undefined') {
+      if (isDark) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
     }
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+
+    safeSetItem('theme', isDark ? 'dark' : 'light');
   }, [isDark]);
 
   const toggleTheme = () => {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,42 @@
+export function isBrowserEnvironment(): boolean {
+  return typeof window !== 'undefined';
+}
+
+export function safeGetItem(key: string): string | null {
+  if (!isBrowserEnvironment()) {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    console.warn(`Unable to read ${key} from localStorage`, error);
+    return null;
+  }
+}
+
+export function safeSetItem(key: string, value: string): boolean {
+  if (!isBrowserEnvironment()) {
+    return false;
+  }
+
+  try {
+    window.localStorage.setItem(key, value);
+    return true;
+  } catch (error) {
+    console.warn(`Unable to write ${key} to localStorage`, error);
+    return false;
+  }
+}
+
+export function safeRemoveItem(key: string): void {
+  if (!isBrowserEnvironment()) {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(key);
+  } catch (error) {
+    console.warn(`Unable to remove ${key} from localStorage`, error);
+  }
+}


### PR DESCRIPTION
## Summary
- add safe localStorage helper utilities to prevent crashes when storage is unavailable
- update theme and data contexts to rely on guarded storage access
- harden the settings page against missing browser APIs during load/reset/export

## Testing
- npm run build
- npm run lint *(fails: pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d41978e018833192740eb28c4d73fe