### PR TITLE
Harden data hydration against invalid stored payloads

### DIFF
--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import { safeGetItem, safeRemoveItem, safeSetItem } from '../utils/storage';
 
 interface FinancialData {
   revenue: { current: number; previous: number };
@@ -54,83 +55,295 @@ interface DataContextType {
 
 const DataContext = createContext<DataContextType | undefined>(undefined);
 
-export function DataProvider({ children }: { children: React.ReactNode }) {
-  const [financialData, setFinancialData] = useState<FinancialData>({
-    revenue: { current: 12500000, previous: 10850000 },
-    ebitda: { current: 2100000, previous: 1850000 },
-    ebitdaNormalized: 1935000,
-    netDebt: { current: 950000, previous: 1080000 },
-    workingCapital: { current: 1800000, previous: 1950000 }
+const FINANCIAL_DATA_KEY = 'pegase_financial_data';
+const QOE_ADJUSTMENTS_KEY = 'pegase_qoe_adjustments';
+const IMPORTED_FILES_KEY = 'pegase_imported_files';
+const LAST_SAVE_KEY = 'pegase_last_save';
+
+const DEFAULT_FINANCIAL_DATA: FinancialData = {
+  revenue: { current: 12500000, previous: 10850000 },
+  ebitda: { current: 2100000, previous: 1850000 },
+  ebitdaNormalized: 1935000,
+  netDebt: { current: 950000, previous: 1080000 },
+  workingCapital: { current: 1800000, previous: 1950000 }
+};
+
+const DEFAULT_QOE_ADJUSTMENTS: QoEAdjustment[] = [
+  {
+    id: '1',
+    item: 'Prime dirigeant exceptionnelle',
+    amount: -85000,
+    type: 'remove',
+    category: 'Owner benefit',
+    confidence: 95,
+    status: 'pending',
+    description: 'Prime versée au dirigeant non récurrente',
+    dateAdded: '2025-01-15T10:30:00Z'
+  },
+  {
+    id: '2',
+    item: 'Gain cession immobilier',
+    amount: -120000,
+    type: 'remove',
+    category: 'Non-récurrent',
+    confidence: 98,
+    status: 'accepted',
+    description: 'Plus-value exceptionnelle sur cession terrain',
+    dateAdded: '2025-01-15T09:15:00Z'
+  },
+  {
+    id: '3',
+    item: 'Provision restructuration',
+    amount: 45000,
+    type: 'add',
+    category: 'Normalisation',
+    confidence: 87,
+    status: 'pending',
+    description: 'Coûts de restructuration non récurrents',
+    dateAdded: '2025-01-15T08:45:00Z'
+  }
+];
+
+const DEFAULT_IMPORTED_FILES: ImportedFile[] = [
+  {
+    id: '1',
+    name: 'FEC_2024_SOCIETE_ABC.txt',
+    size: '2.5MB',
+    type: 'FEC',
+    status: 'completed',
+    progress: 100,
+    dateImported: '2025-01-15T14:30:00Z',
+    controls: {
+      totalLines: 8547,
+      validLines: 8523,
+      warnings: 15,
+      errors: 2
+    }
+  },
+  {
+    id: '2',
+    name: 'Balance_Dec2024.xlsx',
+    size: '450KB',
+    type: 'Balance',
+    status: 'completed',
+    progress: 100,
+    dateImported: '2025-01-14T16:20:00Z',
+    controls: {
+      totalLines: 342,
+      validLines: 342,
+      warnings: 0,
+      errors: 0
+    }
+  }
+];
+
+const QOE_TYPES: QoEAdjustment['type'][] = ['add', 'remove'];
+const QOE_CATEGORIES: QoEAdjustment['category'][] = ['Non-récurrent', 'Owner benefit', 'Normalisation'];
+const QOE_STATUSES: QoEAdjustment['status'][] = ['pending', 'accepted', 'rejected'];
+const IMPORT_TYPES: ImportedFile['type'][] = ['FEC', 'Balance', 'GL', 'Auxiliaire'];
+const IMPORT_STATUSES: ImportedFile['status'][] = ['uploading', 'processing', 'completed', 'error'];
+
+type FinancialMetric = FinancialData['revenue'];
+type FinancialDataShape = Partial<{
+  revenue: Partial<FinancialMetric>;
+  ebitda: Partial<FinancialMetric>;
+  ebitdaNormalized: unknown;
+  netDebt: Partial<FinancialMetric>;
+  workingCapital: Partial<FinancialMetric>;
+}>;
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function createDefaultFinancialData(): FinancialData {
+  return {
+    revenue: { ...DEFAULT_FINANCIAL_DATA.revenue },
+    ebitda: { ...DEFAULT_FINANCIAL_DATA.ebitda },
+    ebitdaNormalized: DEFAULT_FINANCIAL_DATA.ebitdaNormalized,
+    netDebt: { ...DEFAULT_FINANCIAL_DATA.netDebt },
+    workingCapital: { ...DEFAULT_FINANCIAL_DATA.workingCapital }
+  };
+}
+
+function createDefaultQoeAdjustments(): QoEAdjustment[] {
+  return DEFAULT_QOE_ADJUSTMENTS.map(adjustment => ({ ...adjustment }));
+}
+
+function createDefaultImportedFiles(): ImportedFile[] {
+  return DEFAULT_IMPORTED_FILES.map(file => ({
+    ...file,
+    controls: file.controls ? { ...file.controls } : undefined
+  }));
+}
+
+function parseJSON<T>(value: string | null, key: string): T | undefined {
+  if (value === null) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    console.warn(`Stored data for ${key} could not be parsed`, error);
+    return undefined;
+  }
+}
+
+function sanitizeMetric(metric: Partial<FinancialMetric> | undefined, fallback: FinancialMetric): FinancialMetric {
+  const current = toFiniteNumber(metric?.current);
+  const previous = toFiniteNumber(metric?.previous);
+
+  return {
+    current: current ?? fallback.current,
+    previous: previous ?? fallback.previous
+  };
+}
+
+function sanitizeFinancialData(raw: unknown): FinancialData {
+  if (!raw || typeof raw !== 'object') {
+    return createDefaultFinancialData();
+  }
+
+  const data = raw as FinancialDataShape;
+
+  return {
+    revenue: sanitizeMetric(data.revenue, DEFAULT_FINANCIAL_DATA.revenue),
+    ebitda: sanitizeMetric(data.ebitda, DEFAULT_FINANCIAL_DATA.ebitda),
+    ebitdaNormalized:
+      toFiniteNumber(data.ebitdaNormalized) ?? DEFAULT_FINANCIAL_DATA.ebitdaNormalized,
+    netDebt: sanitizeMetric(data.netDebt, DEFAULT_FINANCIAL_DATA.netDebt),
+    workingCapital: sanitizeMetric(data.workingCapital, DEFAULT_FINANCIAL_DATA.workingCapital)
+  };
+}
+
+function sanitizeQoeAdjustments(raw: unknown): QoEAdjustment[] | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const sanitized: QoEAdjustment[] = [];
+
+  raw.forEach(entry => {
+    if (!entry || typeof entry !== 'object') {
+      return;
+    }
+
+    const candidate = entry as Partial<QoEAdjustment>;
+    const amount = toFiniteNumber(candidate.amount);
+    const confidence = toFiniteNumber(candidate.confidence);
+
+    if (
+      typeof candidate.id !== 'string' ||
+      typeof candidate.item !== 'string' ||
+      amount === null ||
+      !QOE_TYPES.includes(candidate.type as QoEAdjustment['type']) ||
+      !QOE_CATEGORIES.includes(candidate.category as QoEAdjustment['category']) ||
+      confidence === null ||
+      typeof candidate.description !== 'string' ||
+      typeof candidate.dateAdded !== 'string' ||
+      !QOE_STATUSES.includes(candidate.status as QoEAdjustment['status'])
+    ) {
+      return;
+    }
+
+    sanitized.push({
+      id: candidate.id,
+      item: candidate.item,
+      amount,
+      type: candidate.type as QoEAdjustment['type'],
+      category: candidate.category as QoEAdjustment['category'],
+      confidence: Math.max(0, Math.min(100, confidence)),
+      status: candidate.status as QoEAdjustment['status'],
+      description: candidate.description,
+      dateAdded: candidate.dateAdded
+    });
   });
 
-  const [qoeAdjustments, setQoeAdjustments] = useState<QoEAdjustment[]>([
-    {
-      id: '1',
-      item: 'Prime dirigeant exceptionnelle',
-      amount: -85000,
-      type: 'remove',
-      category: 'Owner benefit',
-      confidence: 95,
-      status: 'pending',
-      description: 'Prime versée au dirigeant non récurrente',
-      dateAdded: '2025-01-15T10:30:00Z'
-    },
-    {
-      id: '2',
-      item: 'Gain cession immobilier',
-      amount: -120000,
-      type: 'remove',
-      category: 'Non-récurrent',
-      confidence: 98,
-      status: 'accepted',
-      description: 'Plus-value exceptionnelle sur cession terrain',
-      dateAdded: '2025-01-15T09:15:00Z'
-    },
-    {
-      id: '3',
-      item: 'Provision restructuration',
-      amount: 45000,
-      type: 'add',
-      category: 'Normalisation',
-      confidence: 87,
-      status: 'pending',
-      description: 'Coûts de restructuration non récurrents',
-      dateAdded: '2025-01-15T08:45:00Z'
-    }
-  ]);
+  return sanitized;
+}
 
-  const [importedFiles, setImportedFiles] = useState<ImportedFile[]>([
-    {
-      id: '1',
-      name: 'FEC_2024_SOCIETE_ABC.txt',
-      size: '2.5MB',
-      type: 'FEC',
-      status: 'completed',
-      progress: 100,
-      dateImported: '2025-01-15T14:30:00Z',
-      controls: {
-        totalLines: 8547,
-        validLines: 8523,
-        warnings: 15,
-        errors: 2
-      }
-    },
-    {
-      id: '2',
-      name: 'Balance_Dec2024.xlsx',
-      size: '450KB',
-      type: 'Balance',
-      status: 'completed',
-      progress: 100,
-      dateImported: '2025-01-14T16:20:00Z',
-      controls: {
-        totalLines: 342,
-        validLines: 342,
-        warnings: 0,
-        errors: 0
+function sanitizeImportedFiles(raw: unknown): ImportedFile[] | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const sanitized: ImportedFile[] = [];
+
+  raw.forEach(entry => {
+    if (!entry || typeof entry !== 'object') {
+      return;
+    }
+
+    const candidate = entry as Partial<ImportedFile>;
+    const progress = toFiniteNumber(candidate.progress);
+
+    if (
+      typeof candidate.id !== 'string' ||
+      typeof candidate.name !== 'string' ||
+      typeof candidate.size !== 'string' ||
+      !IMPORT_TYPES.includes(candidate.type as ImportedFile['type']) ||
+      !IMPORT_STATUSES.includes(candidate.status as ImportedFile['status']) ||
+      progress === null ||
+      typeof candidate.dateImported !== 'string' ||
+      Number.isNaN(new Date(candidate.dateImported).getTime())
+    ) {
+      return;
+    }
+
+    let controls: ImportedFile['controls'] | undefined;
+    if (candidate.controls && typeof candidate.controls === 'object') {
+      const controlsCandidate = candidate.controls as Partial<ImportedFile['controls']>;
+      const totalLines = toFiniteNumber(controlsCandidate.totalLines);
+      const validLines = toFiniteNumber(controlsCandidate.validLines);
+      const warnings = toFiniteNumber(controlsCandidate.warnings);
+      const errors = toFiniteNumber(controlsCandidate.errors);
+
+      if (
+        totalLines !== null &&
+        validLines !== null &&
+        warnings !== null &&
+        errors !== null
+      ) {
+        controls = {
+          totalLines,
+          validLines,
+          warnings,
+          errors
+        };
       }
     }
-  ]);
+
+    sanitized.push({
+      id: candidate.id,
+      name: candidate.name,
+      size: candidate.size,
+      type: candidate.type as ImportedFile['type'],
+      status: candidate.status as ImportedFile['status'],
+      progress: Math.max(0, Math.min(100, progress)),
+      dateImported: candidate.dateImported,
+      controls
+    });
+  });
+
+  return sanitized;
+}
+
+export function DataProvider({ children }: { children: React.ReactNode }) {
+  const [financialData, setFinancialData] = useState<FinancialData>(() => createDefaultFinancialData());
+  const [qoeAdjustments, setQoeAdjustments] = useState<QoEAdjustment[]>(() => createDefaultQoeAdjustments());
+  const [importedFiles, setImportedFiles] = useState<ImportedFile[]>(() => createDefaultImportedFiles());
 
   const addQoeAdjustment = (adjustment: Omit<QoEAdjustment, 'id' | 'dateAdded'>) => {
     const newAdjustment: QoEAdjustment = {
@@ -160,54 +373,57 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     setImportedFiles(prev => [...prev, newFile]);
   };
 
-  const saveData = () => {
+  const saveData = useCallback(() => {
     try {
-      localStorage.setItem('pegase_financial_data', JSON.stringify(financialData));
-      localStorage.setItem('pegase_qoe_adjustments', JSON.stringify(qoeAdjustments));
-      localStorage.setItem('pegase_imported_files', JSON.stringify(importedFiles));
-      localStorage.setItem('pegase_last_save', new Date().toISOString());
+      safeSetItem(FINANCIAL_DATA_KEY, JSON.stringify(financialData));
+      safeSetItem(QOE_ADJUSTMENTS_KEY, JSON.stringify(qoeAdjustments));
+      safeSetItem(IMPORTED_FILES_KEY, JSON.stringify(importedFiles));
+      safeSetItem(LAST_SAVE_KEY, new Date().toISOString());
     } catch (error) {
       console.error('Error saving data:', error);
     }
-  };
+  }, [financialData, qoeAdjustments, importedFiles]);
 
-  const loadData = () => {
+  const loadData = useCallback(() => {
     try {
-      const savedFinancialData = localStorage.getItem('pegase_financial_data');
-      const savedQoeAdjustments = localStorage.getItem('pegase_qoe_adjustments');
-      const savedImportedFiles = localStorage.getItem('pegase_imported_files');
+      const savedFinancialData = parseJSON<unknown>(safeGetItem(FINANCIAL_DATA_KEY), FINANCIAL_DATA_KEY);
+      if (savedFinancialData !== undefined) {
+        setFinancialData(sanitizeFinancialData(savedFinancialData));
+      }
 
-      if (savedFinancialData) {
-        setFinancialData(JSON.parse(savedFinancialData));
+      const savedQoeAdjustments = parseJSON<unknown>(safeGetItem(QOE_ADJUSTMENTS_KEY), QOE_ADJUSTMENTS_KEY);
+      if (savedQoeAdjustments !== undefined) {
+        const sanitizedAdjustments = sanitizeQoeAdjustments(savedQoeAdjustments);
+        if (sanitizedAdjustments !== undefined) {
+          setQoeAdjustments(sanitizedAdjustments);
+        }
       }
-      if (savedQoeAdjustments) {
-        setQoeAdjustments(JSON.parse(savedQoeAdjustments));
-      }
-      if (savedImportedFiles) {
-        setImportedFiles(JSON.parse(savedImportedFiles));
+
+      const savedImportedFiles = parseJSON<unknown>(safeGetItem(IMPORTED_FILES_KEY), IMPORTED_FILES_KEY);
+      if (savedImportedFiles !== undefined) {
+        const sanitizedFiles = sanitizeImportedFiles(savedImportedFiles);
+        if (sanitizedFiles !== undefined) {
+          setImportedFiles(sanitizedFiles);
+        }
       }
     } catch (error) {
       console.error('Error loading data:', error);
+      setFinancialData(createDefaultFinancialData());
+      setQoeAdjustments(createDefaultQoeAdjustments());
+      setImportedFiles(createDefaultImportedFiles());
     }
-  };
+  }, []);
 
-  const clearData = () => {
-    localStorage.removeItem('pegase_financial_data');
-    localStorage.removeItem('pegase_qoe_adjustments');
-    localStorage.removeItem('pegase_imported_files');
-    localStorage.removeItem('pegase_last_save');
-    
-    // Reset to default values
-    setFinancialData({
-      revenue: { current: 12500000, previous: 10850000 },
-      ebitda: { current: 2100000, previous: 1850000 },
-      ebitdaNormalized: 1935000,
-      netDebt: { current: 950000, previous: 1080000 },
-      workingCapital: { current: 1800000, previous: 1950000 }
-    });
-    setQoeAdjustments([]);
-    setImportedFiles([]);
-  };
+  const clearData = useCallback(() => {
+    safeRemoveItem(FINANCIAL_DATA_KEY);
+    safeRemoveItem(QOE_ADJUSTMENTS_KEY);
+    safeRemoveItem(IMPORTED_FILES_KEY);
+    safeRemoveItem(LAST_SAVE_KEY);
+
+    setFinancialData(createDefaultFinancialData());
+    setQoeAdjustments(createDefaultQoeAdjustments());
+    setImportedFiles(createDefaultImportedFiles());
+  }, []);
 
   // Auto-save every 30 seconds
   useEffect(() => {
@@ -216,12 +432,12 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     }, 30000);
 
     return () => clearInterval(interval);
-  }, [financialData, qoeAdjustments, importedFiles]);
+  }, [saveData]);
 
   // Load data on mount
   useEffect(() => {
     loadData();
-  }, []);
+  }, [loadData]);
 
   return (
     <DataContext.Provider value={{

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import { safeGetItem, safeSetItem } from '../utils/storage';
 
 interface ThemeContextType {
   isDark: boolean;
@@ -9,17 +10,20 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [isDark, setIsDark] = useState(() => {
-    const saved = localStorage.getItem('theme');
+    const saved = safeGetItem('theme');
     return saved ? saved === 'dark' : false;
   });
 
   useEffect(() => {
-    if (isDark) {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
+    if (typeof document !== 'undefined') {
+      if (isDark) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
     }
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+
+    safeSetItem('theme', isDark ? 'dark' : 'light');
   }, [isDark]);
 
   const toggleTheme = () => {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,42 @@
+export function isBrowserEnvironment(): boolean {
+  return typeof window !== 'undefined';
+}
+
+export function safeGetItem(key: string): string | null {
+  if (!isBrowserEnvironment()) {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    console.warn(`Unable to read ${key} from localStorage`, error);
+    return null;
+  }
+}
+
+export function safeSetItem(key: string, value: string): boolean {
+  if (!isBrowserEnvironment()) {
+    return false;
+  }
+
+  try {
+    window.localStorage.setItem(key, value);
+    return true;
+  } catch (error) {
+    console.warn(`Unable to write ${key} to localStorage`, error);
+    return false;
+  }
+}
+
+export function safeRemoveItem(key: string): void {
+  if (!isBrowserEnvironment()) {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(key);
+  } catch (error) {
+    console.warn(`Unable to remove ${key} from localStorage`, error);
+  }
+}


### PR DESCRIPTION
## Summary
- sanitize persisted financial, QoE, and imported file data before hydrating state to avoid runtime crashes
- centralize default datasets and reuse clones when resetting or clearing storage
- wrap persistence helpers in useCallback and reuse new storage key constants for safer saves and loads

## Testing
- npm run build
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d41978e018833192740eb28c4d73fe